### PR TITLE
Making the website easier to navigate

### DIFF
--- a/content/pages/de/community.md
+++ b/content/pages/de/community.md
@@ -7,5 +7,6 @@ Translation: true
 Holen Sie sich Unterstützung beim Einsatz von Sozi, stellen und beantworten Sie Fragen,
 tauschen Sie Tipps und Tricks aus und teilen Sie Ihre Erzeugnisse:
 
+* [Bei der Weiterentwicklung von Sozi helfen](|filename|contribute.md)
 * [Besuchen Sie das Sozi-Forum](/community)
 * [Lesen Sie alles über unsere Datenschutzrichtlinien](|filename|privacy.md)

--- a/content/pages/de/documentation.md
+++ b/content/pages/de/documentation.md
@@ -7,3 +7,4 @@ Translation: true
 * [Präsentationen erstellen](|filename|create.md)
 * [Präsentationen abspielen](|filename|play.md)
 * [Oft gestellte Fragen (FAQ) und Problemlösungen](|filename|faq.md)
+* [Präsentationen demos](https://senshu.github.io/Sozi-demos){:target="_blank"}

--- a/content/pages/de/documentation.md
+++ b/content/pages/de/documentation.md
@@ -6,5 +6,4 @@ Translation: true
 
 * [Präsentationen erstellen](|filename|create.md)
 * [Präsentationen abspielen](|filename|play.md)
-* [Bei der Weiterentwicklung von Sozi helfen](|filename|contribute.md)
 * [Oft gestellte Fragen (FAQ) und Problemlösungen](|filename|faq.md)

--- a/content/pages/de/documentation.md
+++ b/content/pages/de/documentation.md
@@ -4,7 +4,24 @@ Lang: de
 Authors: Guillaume Savaton, Alfred Bergkemper
 Translation: true
 
-* [Präsentationen erstellen](|filename|create.md)
+###Präsentationen erstellen
+
+* [Deine erste Präsentation](|filename|tutorial-first.md)
+* [Der Gebrauch von Ebenen](|filename|tutorial-layers.md)
+<!-- * [Übergänge](|filename|tutorial-transitions.md) -->
+* [Bild-URLs und Links](|filename|tutorial-links.md)
+* [Sozi-Dokumente in HTML-Dateien einbetten](|filename|tutorial-embedding.md)
+<!-- * [Elemente zeigen und verbergen](|filename|tutorial-showing-hiding.md) -->
+* [Audio und Video einbetten](|filename|tutorial-media.md)
+* [Sozi-Präsentationen als pdf-Datei oder Video exportieren](|filename|tutorial-converting.md)
+* [Die Darstellungsperformance verbessern](|filename|tutorial-performance.md)
+
+
+###Präsentationen abspielen
+
 * [Präsentationen abspielen](|filename|play.md)
+
+###Andere
+
 * [Oft gestellte Fragen (FAQ) und Problemlösungen](|filename|faq.md)
 * [Präsentationen demos](https://senshu.github.io/Sozi-demos){:target="_blank"}

--- a/content/pages/de/documentation.md
+++ b/content/pages/de/documentation.md
@@ -1,10 +1,9 @@
 Title: Dokumentation
-Slug: 20-documentation
+Slug: 30-documentation
 Lang: de
 Authors: Guillaume Savaton, Alfred Bergkemper
 Translation: true
 
-* [Sozi installieren](|filename|install.md)
 * [Präsentationen erstellen](|filename|create.md)
 * [Präsentationen abspielen](|filename|play.md)
 * [Bei der Weiterentwicklung von Sozi helfen](|filename|contribute.md)

--- a/content/pages/de/documentation.md
+++ b/content/pages/de/documentation.md
@@ -4,7 +4,7 @@ Lang: de
 Authors: Guillaume Savaton, Alfred Bergkemper
 Translation: true
 
-###Präsentationen erstellen
+##Präsentationen erstellen
 
 * [Deine erste Präsentation](|filename|tutorial-first.md)
 * [Der Gebrauch von Ebenen](|filename|tutorial-layers.md)
@@ -17,11 +17,11 @@ Translation: true
 * [Die Darstellungsperformance verbessern](|filename|tutorial-performance.md)
 
 
-###Präsentationen abspielen
+##Präsentationen abspielen
 
 * [Präsentationen abspielen](|filename|play.md)
 
-###Andere
+##Andere
 
 * [Oft gestellte Fragen (FAQ) und Problemlösungen](|filename|faq.md)
 * [Präsentationen demos](https://senshu.github.io/Sozi-demos){:target="_blank"}

--- a/content/pages/de/install.md
+++ b/content/pages/de/install.md
@@ -1,8 +1,7 @@
 Title: Installation
-Slug: install
+Slug: 20-install
 Lang: de
 Translation: true
-Status: hidden
 Authors: Guillaume Savaton, Andrej Barth
 
 > Read this page in English for an up-to-date version.

--- a/content/pages/en/about.md
+++ b/content/pages/en/about.md
@@ -3,16 +3,49 @@ Slug: 10-about
 Lang: en
 Authors: Guillaume Savaton
 
-Sozi is a zooming presentation editor and player.
+##Sozi in a nutshell
 
-Unlike in most presentation applications, a Sozi document is not organised as a slideshow,
+Sozi is a zooming presentation editor and player. Unlike in most presentation applications, a Sozi document is not organised as a slideshow,
 but rather as a poster where the content of your presentation can be freely laid out.
 Playing such a presentation consists in a series of translations, zooms and rotations
 that allow to focus on the elements you want to show.
 
-Sozi is based on open standards.
-It is free software distributed according to the terms of the
-[Mozilla Public License 2.0](http://www.mozilla.org/MPL/2.0/).
+Below is an example of what can be done with Sozi. More examples are shown [here](https://senshu.github.io/Sozi-demos){:target="_blank"}.
 
+[comment]: # (A more day-to-day example would be better here, like a corporate prez with numbers and charts)
+[comment]: # (Evn better, a slideshow about sozi.. in html)
+<br/><br/>
 <iframe class="sozi" src="{static}/presentations/this-is-not-a-slideshow.sozi.html">
 </iframe>
+<br/><br/>
+
+##The Sozi way
+
+Ever been irritated by having to fit your ideas in fixed-size A4 paper sheets? Hard to find the page you're looking 
+for amongst the 70 pages of your presentation? What's the point of A4 pages anyway, as no one prints presentations any more?
+
+With Sozi, draw anything that you want on an unlimited size page, the way you like, with the vector graphics editor of your choice. Sozi turns your drawing into an animation, enabling to browse from place to place and zoom in areas of interest.
+
+Freed from the obsolete A4 paradigm, you can start being creative using truly professional graphics editors, playing with layers, transparency and more.
+
+[comment]: # (We could provide presentation templates, that'd help the users)
+
+##Open standards
+
+Sozi uses open standards from A to Z, which is the core of our philosophy. It takes a vector image in the form of an SVG file, 
+and outputs a single html file. This file contains your presentation and can be shared with others, and played in any internet browser without the need to install additional software. 
+
+Because html is a very solid standard, used by bilions of people around the world, it guarantees that your presentation will play smoothly anywhere, and will remain useable anytime in the future.
+
+##Free licence
+
+Sozi is distributed according to the terms of the [Mozilla Public License 2.0](http://www.mozilla.org/MPL/2.0/), meaning you can use, inspect, modify, and share the code freely. 
+
+No limited-time testing periods or funny hidden features, everything is open. Sozi is still in construction, meaning it improves every day, thanks to the suggestions and contributions of its users.
+
+##Test Sozi
+
+Now that you know Sozi, you can [install it](|filename|install.md), look at [presentation examples](https://senshu.github.io/Sozi-demos){:target="_blank"}, read the [documentation](|filename|documentation.md), inspect the [source code](https://github.com/senshu/Sozi/releases/latest){:target="_blank"}, or post a question on the [forum](./community){:target="_blank"}.
+
+Thank you for your interest in Sozi.
+

--- a/content/pages/en/community.md
+++ b/content/pages/en/community.md
@@ -5,5 +5,6 @@ Authors: Guillaume Savaton
 
 Get support using Sozi, ask and answer questions, exchange tips and best practices, share your creations:
 
+* [Contributing to the development of Sozi](|filename|contribute.md)
 * [Visit the Sozi community forum](/community)
 * [Read our privacy policy](|filename|privacy.md)

--- a/content/pages/en/documentation.md
+++ b/content/pages/en/documentation.md
@@ -4,7 +4,7 @@ Lang: en
 Authors: Guillaume Savaton
 
 
-### Creating presentations
+## Creating presentations
 
 * [Reference manual of the presentation editor](|filename|ui.md)
 * [Your first presentation](|filename|tutorial-first.md)
@@ -17,11 +17,11 @@ Authors: Guillaume Savaton
 * [Converting Sozi presentations to PDF or video](|filename|tutorial-converting.md)
 * [Improving rendering performance](|filename|tutorial-performance.md)
 
-### Playing presentations
+## Playing presentations
 
 * [Playing presentations](|filename|play.md)
 
-### Other
+## Other
 
 * [Frequently Asked Questions and troubleshooting](|filename|faq.md)
 * [Presentations examples](https://senshu.github.io/Sozi-demos){:target="_blank"}

--- a/content/pages/en/documentation.md
+++ b/content/pages/en/documentation.md
@@ -5,5 +5,4 @@ Authors: Guillaume Savaton
 
 * [Creating presentations](|filename|create.md)
 * [Playing presentations](|filename|play.md)
-* [Contributing to the development of Sozi](|filename|contribute.md)
 * [Frequently Asked Questions and troubleshooting](|filename|faq.md)

--- a/content/pages/en/documentation.md
+++ b/content/pages/en/documentation.md
@@ -6,3 +6,4 @@ Authors: Guillaume Savaton
 * [Creating presentations](|filename|create.md)
 * [Playing presentations](|filename|play.md)
 * [Frequently Asked Questions and troubleshooting](|filename|faq.md)
+* [Presentations examples](https://senshu.github.io/Sozi-demos){:target="_blank"}

--- a/content/pages/en/documentation.md
+++ b/content/pages/en/documentation.md
@@ -3,7 +3,25 @@ Slug: 30-documentation
 Lang: en
 Authors: Guillaume Savaton
 
-* [Creating presentations](|filename|create.md)
+
+### Creating presentations
+
+* [Reference manual of the presentation editor](|filename|ui.md)
+* [Your first presentation](|filename|tutorial-first.md)
+* [Using layers](|filename|tutorial-layers.md)
+<!--* [Transition effects](|filename|tutorial-transitions.md)-->
+* [Frame URLs and hyperlinks](|filename|tutorial-links.md)
+* [Embedding Sozi presentations in HTML documents](|filename|tutorial-embedding.md)
+<!--* [Showing and hiding objects](|filename|tutorial-showing-hiding.md)-->
+* [Embedding video and audio](|filename|tutorial-media.md)
+* [Converting Sozi presentations to PDF or video](|filename|tutorial-converting.md)
+* [Improving rendering performance](|filename|tutorial-performance.md)
+
+### Playing presentations
+
 * [Playing presentations](|filename|play.md)
+
+### Other
+
 * [Frequently Asked Questions and troubleshooting](|filename|faq.md)
 * [Presentations examples](https://senshu.github.io/Sozi-demos){:target="_blank"}

--- a/content/pages/en/documentation.md
+++ b/content/pages/en/documentation.md
@@ -1,9 +1,8 @@
 Title: Documentation
-Slug: 20-documentation
+Slug: 30-documentation
 Lang: en
 Authors: Guillaume Savaton
 
-* [Installing Sozi](|filename|install.md)
 * [Creating presentations](|filename|create.md)
 * [Playing presentations](|filename|play.md)
 * [Contributing to the development of Sozi](|filename|contribute.md)

--- a/content/pages/en/install.md
+++ b/content/pages/en/install.md
@@ -1,7 +1,6 @@
 Title: Installation
-Slug: install
+Slug: 20-install
 Lang: en
-Status: hidden
 Authors: Guillaume Savaton
 
 If you use Sozi and would like to support its development,

--- a/content/pages/en/install.md
+++ b/content/pages/en/install.md
@@ -43,19 +43,20 @@ Installing for GNU/Linux
 > for Debian, Ubuntu, and their derivatives which can be found in the 
 > [stable repository](https://github.com/senshu/Sozi/releases/latest){:target="_blank"}.
 
-
-Download the `.deb` file that corresponds to your platform (`i386` or `amd64`),
+###Ubuntu derivatives (*buntu, debian, Linux Mint)
+Download the `.deb` file that corresponds to your platform (`i386` or `amd64`) in the 
+[stable repository](https://github.com/senshu/Sozi/releases/latest){:target="_blank"},
 open a terminal and run the following command:
 
 ```bash
 sudo dpkg -i sozi_{version}_{arch}.deb
 ```
-
+###Archlinux
 Archlinux users can install Sozi from the [Archlinux User Repository](https://aur.archlinux.org/packages/sozi).
 
-### Installing from a zip archive
+### Other distribs
 
-In other cases, download the `.tgz` file that corresponds to your platform (`linux-ia32` or `linux-x64`).
+In other cases, download the `.tgz` file that corresponds to your platform (`linux-ia32` or `linux-x64`) in the [stable repository](https://github.com/senshu/Sozi/releases/latest){:target="_blank"}.
 In a terminal, execute the following commands:
 
 ```bash

--- a/content/pages/en/install.md
+++ b/content/pages/en/install.md
@@ -3,18 +3,34 @@ Slug: 20-install
 Lang: en
 Authors: Guillaume Savaton
 
-If you use Sozi and would like to support its development,
-you can [contribute](|filename|contribute.md),
-or [buy something](https://www.spreadshirt.fr/user/Guillaume+Savaton),
-[buy me a coffee](https://www.buymeacoffee.com/THtbNvnqE),
-or [make a donation by another mean](|filename|donate.md).
 
-* [Download the latest release](https://github.com/senshu/Sozi/releases/latest)
-* [Download a preview version of the next release](https://drive.google.com/open?id=0ByRUreHgekjMWG9teGM2dE8wck0) (for testers)
-* [Installing for GNU/Linux](#installing-for-gnulinux)
-* [Installing for Windows](#installing-for-windows)
-* [Installing for OS X](#installing-for-os-x)
-* [Installing from a Docker image](#installing-from-a-docker-image)
+
+
+Select your environment and release version
+-------------------------------------------
+
+
+###Installing the latest version (best choice for most users):
+
+* [Installing the latest version for GNU/Linux](#installing-for-gnulinux)
+* [Installing the latest version for Windows](#installing-for-windows)
+* [Installing the latest version for OS X](#installing-for-os-x)
+* [Installing the latest version from a Docker image](#installing-from-a-docker-image)
+
+###Getting alternative releases (for testers or special cases):
+
+* [Installing an older version](#installing-an-older-version)
+* [Installing a preview version of the next release](#installing-a-preview-version) 
+
+
+**Note: If you use Sozi and would like to support its development,**
+**you can [contribute](|filename|contribute.md),**
+**or [buy something](https://www.spreadshirt.fr/user/Guillaume+Savaton),**
+**[buy me a coffee](https://www.buymeacoffee.com/THtbNvnqE),**
+**or [make a donation by another mean](|filename|donate.md).**
+
+
+
 
 Installing for GNU/Linux
 ------------------------
@@ -23,9 +39,11 @@ Installing for GNU/Linux
 > provide very outdated versions of Sozi.
 > You can still install them, but be aware that no documentation or support
 > will be available.
+> Starting from Sozi 18, we provide packages of the Sozi executable
+> for Debian, Ubuntu, and their derivatives which can be found in the 
+> [stable repository](https://github.com/senshu/Sozi/releases/latest){:target="_blank"}.
 
-Starting from Sozi 18, we provide packages of the presentation editor
-for Debian, Ubuntu, and their derivatives.
+
 Download the `.deb` file that corresponds to your platform (`i386` or `amd64`),
 open a terminal and run the following command:
 
@@ -62,9 +80,9 @@ or from the command-line as `sozi` (in lower case).
 Installing for Windows
 ----------------------
 
-Sozi for Windows is only distributed in the form of a zip archive.
-No installer is provided.
-Download one of the following files:
+Sozi for Windows is only distributed in the form of a zip archive, no installer is provided.
+Download one of the following files from the 
+[stable repository](https://github.com/senshu/Sozi/releases/latest){:target="_blank"}:
 
 * `sozi-{version}-windows-ia32.zip` for Windows, 32-bit.
 * `sozi-{version}-windows-ia64.zip` for Windows, 64-bit.
@@ -77,7 +95,8 @@ Installing for OS X
 
 Sozi for OS X is distributed in the form of a zip archive named
 `sozi-{version}-osx-ia64.tgz` (for Sozi 17 or below, the file was named
-`sozi-{version}-darwin-ia64.tgz`).
+`sozi-{version}-darwin-ia64.tgz`), available in the 
+[stable repository](https://github.com/senshu/Sozi/releases/latest){:target="_blank"}.
 
 Extract the archive.
 It will create a folder with the same name, containing a subbolder `Sozi.app`.
@@ -134,8 +153,8 @@ This image has been created by [Jorge Gomez](https://github.com/escalope).
 It is hosted in [the inkscape-sozi Docker Hub repository](https://hub.docker.com/r/escalope/inkscape-sozi).
 The source Dockerfile can be found in [the dockerfile-sozi GitHub repository](https://github.com/escalope/dockerfile-sozi).
 
-Sozi 13
--------
+Installing an older version
+----------------------------
 
 Sozi 13.11 is still available if you need it, but it is no longer maintained:
 
@@ -144,3 +163,11 @@ Sozi 13.11 is still available if you need it, but it is no longer maintained:
 * [Install Sozi 13 on GNU/Linux](|filename|sozi-13-install-linux.md)
 * [Install Sozi 13 on Windows](|filename|sozi-13-install-windows.md)
 * [Install Sozi 13 on Mac OS X](|filename|sozi-13-install-osx.md)
+
+Installing a preview version
+----------------------------
+
+For developpers who would like to view the latest code, it is available in the 
+[preview repository](https://drive.google.com/open?id=0ByRUreHgekjMWG9teGM2dE8wck0){:target="_blank"}.
+
+The code is experimental and should only be used by experienced users.

--- a/content/pages/fr/community.md
+++ b/content/pages/fr/community.md
@@ -7,5 +7,6 @@ Authors: Guillaume Savaton
 Pour obtenir de l'aide dans l'utilisation de Sozi, poser des questions ou y répondre,
 échanger des astuces et des bonnes pratiques, partager vos créations&nbsp;:
 
+* [Contribuer au développement de Sozi](|filename|contribute.md)
 * [Visit the Sozi community forum](/community)
 * [Read our privacy policy](|filename|privacy.md)

--- a/content/pages/fr/documentation.md
+++ b/content/pages/fr/documentation.md
@@ -6,5 +6,4 @@ Authors: Guillaume Savaton
 
 * [Créer une présentation](|filename|create.md)
 * [Jouer une presentation](|filename|play.md)
-* [Contribuer au développement de Sozi](|filename|contribute.md)
 * [Foire Aux Questions et résolution des problèmes](|filename|faq.md)

--- a/content/pages/fr/documentation.md
+++ b/content/pages/fr/documentation.md
@@ -1,10 +1,9 @@
 Title: Documentation
-Slug: 20-documentation
+Slug: 30-documentation
 Lang: fr
 Translation: true
 Authors: Guillaume Savaton
 
-* [Installer Sozi](|filename|install.md)
 * [Créer une présentation](|filename|create.md)
 * [Jouer une presentation](|filename|play.md)
 * [Contribuer au développement de Sozi](|filename|contribute.md)

--- a/content/pages/fr/documentation.md
+++ b/content/pages/fr/documentation.md
@@ -7,3 +7,4 @@ Authors: Guillaume Savaton
 * [Créer une présentation](|filename|create.md)
 * [Jouer une presentation](|filename|play.md)
 * [Foire Aux Questions et résolution des problèmes](|filename|faq.md)
+* [Exemples de présentations](https://senshu.github.io/Sozi-demos){:target="_blank"}

--- a/content/pages/fr/documentation.md
+++ b/content/pages/fr/documentation.md
@@ -4,7 +4,7 @@ Lang: fr
 Translation: true
 Authors: Guillaume Savaton
 
-### Créer une présentation
+## Créer une présentation
 
 * [Manuel de référence de l'éditeur de présentations](|filename|ui.md)
 * [Votre première présentation](|filename|tutorial-first.md)
@@ -17,11 +17,11 @@ Authors: Guillaume Savaton
 * [Convertir les présentations Sozi en PDF ou en vidéo](|filename|tutorial-converting.md)
 * [Améliorer les performances](|filename|tutorial-performance.md)
 
-### Jouer une présentation
+## Jouer une présentation
 
 * [Jouer une presentation](|filename|play.md)
 
-###Autres
+##Autres
 
 * [Foire Aux Questions et résolution des problèmes](|filename|faq.md)
 * [Exemples de présentations](https://senshu.github.io/Sozi-demos){:target="_blank"}

--- a/content/pages/fr/documentation.md
+++ b/content/pages/fr/documentation.md
@@ -4,7 +4,24 @@ Lang: fr
 Translation: true
 Authors: Guillaume Savaton
 
-* [Créer une présentation](|filename|create.md)
+### Créer une présentation
+
+* [Manuel de référence de l'éditeur de présentations](|filename|ui.md)
+* [Votre première présentation](|filename|tutorial-first.md)
+* [Utiliser les calques](|filename|tutorial-layers.md)
+<!--* [Les effets de transition](|filename|tutorial-transitions.md)-->
+* [Créer un lien vers une vue ou une URL](|filename|tutorial-links.md)
+* [Insérer une présentation Sozi dans une page HTML](|filename|tutorial-embedding.md)
+<!--* [Montrer et cacher des objets](|filename|tutorial-showing-hiding.md)-->
+* [Insérer de l'audio ou une vidéo](|filename|tutorial-media.md)
+* [Convertir les présentations Sozi en PDF ou en vidéo](|filename|tutorial-converting.md)
+* [Améliorer les performances](|filename|tutorial-performance.md)
+
+### Jouer une présentation
+
 * [Jouer une presentation](|filename|play.md)
+
+###Autres
+
 * [Foire Aux Questions et résolution des problèmes](|filename|faq.md)
 * [Exemples de présentations](https://senshu.github.io/Sozi-demos){:target="_blank"}

--- a/content/pages/fr/install.md
+++ b/content/pages/fr/install.md
@@ -1,8 +1,7 @@
 Title: Installation
-Slug: install
+Slug: 20-install
 Lang: fr
 Translation: true
-Status: hidden
 Authors: Guillaume Savaton
 
 Si vous utilisez Sozi et souhaitez soutenir son développement,

--- a/content/pages/fr/install.md
+++ b/content/pages/fr/install.md
@@ -4,18 +4,29 @@ Lang: fr
 Translation: true
 Authors: Guillaume Savaton
 
-Si vous utilisez Sozi et souhaitez soutenir son développement,
-vous pouvez [contribuer](|filename|contribute.md),
-[acheter un objet](https://www.spreadshirt.fr/user/Guillaume+Savaton),
-[m'offrir un café](https://www.buymeacoffee.com/THtbNvnqE),
-ou [faire un don par un autre moyen](|filename|donate.md).
+Choisissez votre environnement et version
+------------------------------------------
 
-* [Télécharger la dernière version](https://github.com/senshu/Sozi/releases/latest)
-* [Télécharger un aperçu de la prochaine version](https://drive.google.com/open?id=0ByRUreHgekjMWG9teGM2dE8wck0) (pour les testeurs)
+###Pour installer la dernière version (convient pour la plupart des utilisateurs):
+
 * [Installation pour GNU/Linux](#installation-pour-gnulinux)
 * [Installation pour Windows](#installation-pour-windows)
 * [Installation pour OS X](#installation-pour-os-x)
 * [Installation à partir d'une image Docker](#installation-a-partir-dune-image-docker)
+
+###Obtenir des versions alternatives (pour les testeurs et cas particuliers):
+
+* [Installer une version ancienne](#installation-dune-version-ancienne)
+* [Installer la version de développement](#installation-dune-version-de-developpement)
+
+
+**Note: Si vous utilisez Sozi et souhaitez soutenir son développement,**
+**vous pouvez [contribuer](|filename|contribute.md),**
+**[acheter un objet](https://www.spreadshirt.fr/user/Guillaume+Savaton),**
+**[m'offrir un café](https://www.buymeacoffee.com/THtbNvnqE),**
+**ou [faire un don par un autre moyen](|filename|donate.md).**
+
+
 
 Installation pour GNU/Linux
 ---------------------------
@@ -24,9 +35,11 @@ Installation pour GNU/Linux
 > "périmées" de Sozi.
 > Vous pouvez toujours les installer, mais sachez que vous ne trouverez ni
 > assistance, ni documentation.
+> Depuis la version 18, nous fournissons l'éditeur de présentations sous la forme
+> de paquets pour Debian, Ubuntu et leurs dérivées, qui peuvent être trouvés dans le 
+> [dépôt stable](https://github.com/senshu/Sozi/releases/latest){:target="_blank"}.
 
-Depuis la version 18, nous fournissons l'éditeur de présentations sous la forme
-de paquets pour Debian, Ubuntu et leurs dérivées.
+
 Téléchargez le fichier `.deb` correspondant à votre plate-forme (`i386` ou `amd64`),
 ouvrez un terminal et exécutez la commande suivante&nbsp;:
 
@@ -63,9 +76,8 @@ Après installation, Sozi peut être exécuté depuis le menu des applications d
 Installation pour Windows
 -------------------------
 
-Sozi pour Windows est distribué uniquement sous la forme d'une archive zip.
-Aucun programme d'installation n'est fourni.
-Téléchargez l'un des fichiers suivants&nbsp;:
+Sozi pour Windows est distribué uniquement sous la forme d'une archive zip, aucun programme d'installation n'est fourni.
+Téléchargez l'un des fichiers suivants sur le [dépôt stable](https://github.com/senshu/Sozi/releases/latest){:target="_blank"}:
 
 * `sozi-{version}-windows-ia32.zip` pour Windows, 32 bits.
 * `sozi-{version}-windows-ia64.zip` pour Windows, 64 bits.
@@ -79,7 +91,8 @@ Installation pour OS X
 
 Sozi pour OS X est distribué sous la forme d'une archive zip nommée
 `sozi-{version}-osx-ia64.tgz` (pour Sozi 17 et les versions précédentes, le
-fichier était nommé `sozi-{version}-darwin-ia64.tgz`).
+fichier était nommé `sozi-{version}-darwin-ia64.tgz`), disponible sur le 
+[dépôt stable](https://github.com/senshu/Sozi/releases/latest){:target="_blank"}.
 
 En procédant à l'extraction de cette archive, vous verrez apparaître un dossier
 portant le même nom.
@@ -139,8 +152,8 @@ Cette image a été créée par [Jorge Gomez](https://github.com/escalope).
 Elle est hébergée dans [le dépôt inkscape-sozi sur Docker Hub](https://hub.docker.com/r/escalope/inkscape-sozi).
 Le Dockerfile se trouve [dans le dépôt dockerfile-sozi chez GitHub](https://github.com/escalope/dockerfile-sozi).
 
-Sozi 13
--------
+Installation d'une version ancienne
+------------------------------------
 
 Sozi 13.11 est toujours disponible en cas de besoin, mais cette version n'est plus maintenue.
 
@@ -149,3 +162,13 @@ Sozi 13.11 est toujours disponible en cas de besoin, mais cette version n'est pl
 * [Installer Sozi 13 sous GNU/Linux](|filename|sozi-13-install-linux.md)
 * [Installer Sozi 13 sous Windows](|filename|sozi-13-install-windows.md)
 * [Installer Sozi 13 sous Mac OS X](|filename|sozi-13-install-osx.md)
+
+
+
+Installation d'une version de développement
+---------------------------------------------
+
+Pour les développeurs qui voudraient voir le code en cours, celui-ci est disponible sur le [dépôt de développement](https://drive.google.com/open?id=0ByRUreHgekjMWG9teGM2dE8wck0){:target="_blank"}.
+
+Le code est expérimental et ne peut être utilisé que par des utilisateurs expérimentés.
+

--- a/content/pages/fr/install.md
+++ b/content/pages/fr/install.md
@@ -39,20 +39,22 @@ Installation pour GNU/Linux
 > de paquets pour Debian, Ubuntu et leurs dérivées, qui peuvent être trouvés dans le 
 > [dépôt stable](https://github.com/senshu/Sozi/releases/latest){:target="_blank"}.
 
-
-Téléchargez le fichier `.deb` correspondant à votre plate-forme (`i386` ou `amd64`),
+###Dérivées d'Ubuntu (*buntu, debian, Linux Mint)
+Téléchargez le fichier `.deb` correspondant à votre plate-forme (`i386` ou `amd64`), dans le 
+[dépôt stable](https://github.com/senshu/Sozi/releases/latest){:target="_blank"}
 ouvrez un terminal et exécutez la commande suivante&nbsp;:
 
 ```bash
 sudo dpkg -i sozi_{version}_{arch}.deb
 ```
+###Archlinux
 
 Les utilisateurs d'Archlinux peuvent installer Sozi depuis l'[Archlinux User Repository](https://aur.archlinux.org/packages/sozi).
 
-### Installation à partir d'une archive zip
+###Autres distributions
 
 Dans les autres cas, téléchargez le fichier `.tgz` correspondant à votre plate-forme
-(`linux-ia32` ou `linux-x64`).
+(`linux-ia32` ou `linux-x64`) dans le [dépôt stable](https://github.com/senshu/Sozi/releases/latest){:target="_blank"}.
 Dans un terminal, exécutez les commandes suivantes&nbsp;:
 
 ```bash

--- a/content/pages/pt_br/community.md
+++ b/content/pages/pt_br/community.md
@@ -8,5 +8,6 @@ Authors: Guillaume Savaton
 
 Get support using Sozi, ask and answer questions, exchange tips and best practices, share your creations:
 
+* [Contributing to the development of Sozi](|filename|contribute.md)
 * [Visit the Sozi community forum](/community)
 * [Read our privacy policy](|filename|privacy.md)

--- a/content/pages/pt_br/documentation.md
+++ b/content/pages/pt_br/documentation.md
@@ -1,12 +1,11 @@
 Title: Documentação
-Slug: 20-documentation
+Slug: 30-documentation
 Lang: pt_br
 Translation: true
 Authors: Guillaume Savaton
 
 > This page has not been translated yet
 
-* [Installing Sozi](|filename|install.md)
 * [Creating presentations](|filename|create.md)
 * [Playing presentations](|filename|play.md)
 * [Contributing to the development of Sozi](|filename|contribute.md)

--- a/content/pages/pt_br/documentation.md
+++ b/content/pages/pt_br/documentation.md
@@ -6,7 +6,23 @@ Authors: Guillaume Savaton
 
 > This page has not been translated yet
 
-* [Creating presentations](|filename|create.md)
+###Creating presentations
+
+* [Sua primeira apresentação](|filename|tutorial-first.md)
+* [Usando camadas](|filename|tutorial-layers.md)
+<!-- * [Efeitos de transição](|filename|tutorial-transitions.md) -->
+* [URL de quadros e hyperlinks](|filename|tutorial-links.md)
+* [Inserindo apresentações do Sozi em documentos HTML](|filename|tutorial-embedding.md)
+<!-- * [Exibindo e ocultando objetos](|filename|tutorial-showing-hiding.md) -->
+* [Inserindo vídeo e áudio](|filename|tutorial-media.md)
+* [Convertendo apresentações do Sozi para PDF ou vídeo](|filename|tutorial-converting.md)
+* [Melhorando a performance de renderização](|filename|tutorial-performance.md)
+
+###Playing presentations
+
 * [Playing presentations](|filename|play.md)
 * [Questões Frequêntes e Solução de Problemas](|filename|faq.md)
+
+###Others
+
 * [Presentations examples](https://senshu.github.io/Sozi-demos){:target="_blank"}

--- a/content/pages/pt_br/documentation.md
+++ b/content/pages/pt_br/documentation.md
@@ -8,5 +8,4 @@ Authors: Guillaume Savaton
 
 * [Creating presentations](|filename|create.md)
 * [Playing presentations](|filename|play.md)
-* [Contributing to the development of Sozi](|filename|contribute.md)
 * [Questões Frequêntes e Solução de Problemas](|filename|faq.md)

--- a/content/pages/pt_br/documentation.md
+++ b/content/pages/pt_br/documentation.md
@@ -9,3 +9,4 @@ Authors: Guillaume Savaton
 * [Creating presentations](|filename|create.md)
 * [Playing presentations](|filename|play.md)
 * [Questões Frequêntes e Solução de Problemas](|filename|faq.md)
+* [Presentations examples](https://senshu.github.io/Sozi-demos){:target="_blank"}

--- a/content/pages/pt_br/documentation.md
+++ b/content/pages/pt_br/documentation.md
@@ -6,7 +6,7 @@ Authors: Guillaume Savaton
 
 > This page has not been translated yet
 
-###Creating presentations
+##Creating presentations
 
 * [Sua primeira apresentação](|filename|tutorial-first.md)
 * [Usando camadas](|filename|tutorial-layers.md)
@@ -18,11 +18,11 @@ Authors: Guillaume Savaton
 * [Convertendo apresentações do Sozi para PDF ou vídeo](|filename|tutorial-converting.md)
 * [Melhorando a performance de renderização](|filename|tutorial-performance.md)
 
-###Playing presentations
+##Playing presentations
 
 * [Playing presentations](|filename|play.md)
 * [Questões Frequêntes e Solução de Problemas](|filename|faq.md)
 
-###Others
+##Others
 
 * [Presentations examples](https://senshu.github.io/Sozi-demos){:target="_blank"}

--- a/content/pages/pt_br/install.md
+++ b/content/pages/pt_br/install.md
@@ -1,8 +1,7 @@
 Title: Instalação
-Slug: install
+Slug: 20-install
 Lang: pt_br
 Translation: true
-Status: hidden
 Authors: Guillaume Savaton, Marcelo Vaz
 
 > Read this page in English for an up-to-date version.


### PR DESCRIPTION
Hello,

I like Sozi a lot, but I find the website a little difficult to get around.
I've made some modifications to its organization -not modifying content- that make it clearer in my opinion.

If you like the mods I suggest, I can rewrite the "About" page later on, which I think should be expanded with more information.
I also think the 'about' page should be the front page of the site, because a visitor who wants to know about Sozi is looking for a short description, not a list of releases. But I didn't find the way to change this ;)

Talk to you,
JJ

